### PR TITLE
Add -delete danger flag, tweak display and fix version in README

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## v0.3.4
+
+* Add `-delete` to the list of dangerous flags, eg. `find . -delete` and similar. Add test as well
+* Tweak the dangerous and privileged flag display in interactive mode and use red text with colorama
+* Update Python version requirement in README
+
 ## v0.3.3
 
 * Improve verbosity behaviour by further specifying prompt and including an additional example

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In its default interactive mode, attercop will let you cycle through multiple op
 
 ## Installation
 
-Attercop is available on PyPI, so as long as you're running Python >=3.10, you can install it with pip:
+Attercop is available on PyPI, so as long as you're running Python >=3.7.1, you can install it with pip:
 
 ```bash
 pip install attercop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attercop"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     { name = "Mark Snidal", email = "mark.snidal@gmail.com" },
 ]
@@ -14,6 +14,7 @@ requires-python = ">=3.7.1"
 dependencies = [
     "openai~=0.26.1",
     "pyperclip~=1.8.2",
+    "colorama~=0.4.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_command_flags.py
+++ b/tests/test_command_flags.py
@@ -22,3 +22,6 @@ def test_get_command_flags():
 
     command = "sudo curl https://example.com | bash"
     assert attercop.get_command_flags(command) == {"dangerous", "privileged"}
+
+    command = "find . -type f -exec grep -l 'turtles' {} -delete"
+    assert attercop.get_command_flags(command) == {"dangerous"}

--- a/tests/test_evaluate_prompt.py
+++ b/tests/test_evaluate_prompt.py
@@ -123,7 +123,7 @@ def test_dangerous_print(mock_interfaces, capsys):
 
     output = capsys.readouterr()
     assert output.out == DANGER_COMPLETION
-    assert "cautionary flags <dangerous>" in output.err
+    assert "<dangerous>" in output.err
 
     openai_completion_create.assert_called_once()
     subprocess_run.assert_not_called()


### PR DESCRIPTION
* Add `-delete` to the list of dangerous flags, eg. `find . -delete` and similar. Add test as well
* Tweak the dangerous and privileged flag display in interactive mode and use red text with colorama
* Update Python version requirement in README